### PR TITLE
docs: fix typos

### DIFF
--- a/modules/css-basics/README.md
+++ b/modules/css-basics/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"CSS Basic (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **75%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/css-basics/README.md
+++ b/modules/css-basics/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"CSS Basic (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **75%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/css-flex/README.md
+++ b/modules/css-flex/README.md
@@ -17,5 +17,5 @@ In this module you will learn what is CSS Flex, media queries and how to apply i
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be twice lower.
+- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/css-flex/README.md
+++ b/modules/css-flex/README.md
@@ -17,5 +17,5 @@ In this module you will learn what is CSS Flex, media queries and how to apply i
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+- You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/css-grid/README.md
+++ b/modules/css-grid/README.md
@@ -16,5 +16,5 @@ In this module you will learn what is CSS Grid and how to apply it for building 
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be twice lower.
+- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/css-grid/README.md
+++ b/modules/css-grid/README.md
@@ -16,5 +16,5 @@ In this module you will learn what is CSS Grid and how to apply it for building 
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+- You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/dom-api/README.md
+++ b/modules/dom-api/README.md
@@ -21,5 +21,5 @@ In this module you will learn DOM api basic:
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be twice lower.
+- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/dom-api/README.md
+++ b/modules/dom-api/README.md
@@ -21,5 +21,5 @@ In this module you will learn DOM api basic:
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+- You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/dom-events/README.md
+++ b/modules/dom-events/README.md
@@ -20,5 +20,5 @@ In this module you will learn DOM events basic: what is DOM Event, EventTarget, 
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be twice lower.
+- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/dom-events/README.md
+++ b/modules/dom-events/README.md
@@ -20,5 +20,5 @@ In this module you will learn DOM events basic: what is DOM Event, EventTarget, 
 - Tests submitted in RS School App could be solved after authorization in the application.
 - The minimum passing score is **75%** of the maximum possible number of points.
 - You can take the test **3 times**, the last result is counted.
-- You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+- You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 - The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"Git Quiz"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **75%** of the maximum possible number of points.
 * You can take the test **5 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/git/README.md
+++ b/modules/git/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"Git Quiz"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **75%** of the maximum possible number of points.
 * You can take the test **5 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/html-basics/README.md
+++ b/modules/html-basics/README.md
@@ -13,6 +13,6 @@ At the end of this module, you should pass the **"HTML Basic ( EN )"** test.
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **85%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/html-basics/README.md
+++ b/modules/html-basics/README.md
@@ -13,6 +13,6 @@ At the end of this module, you should pass the **"HTML Basic ( EN )"** test.
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **85%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-arrays/README.md
+++ b/modules/js-arrays/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"JS Array. Basic"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-arrays/README.md
+++ b/modules/js-arrays/README.md
@@ -15,6 +15,6 @@ At the end of this module you should pass the **"JS Array. Basic"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-basics-1/README.md
+++ b/modules/js-basics-1/README.md
@@ -20,6 +20,6 @@ At the end of this module you should pass the **"JS-basic. Part 1 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-basics-1/README.md
+++ b/modules/js-basics-1/README.md
@@ -20,6 +20,6 @@ At the end of this module you should pass the **"JS-basic. Part 1 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-basics-2/README.md
+++ b/modules/js-basics-2/README.md
@@ -18,6 +18,6 @@ At the end of this module you should pass the **"JS-basic. Part 2 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-basics-2/README.md
+++ b/modules/js-basics-2/README.md
@@ -18,6 +18,6 @@ At the end of this module you should pass the **"JS-basic. Part 2 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/js-basics-3/README.md
+++ b/modules/js-basics-3/README.md
@@ -18,7 +18,7 @@ At the end of this module you should pass the **"JS-basic. Part 3 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 
 ### Task [Codewars: Strings, Numbers](../../tasks/codewars/codewars.strings.numbers.md)

--- a/modules/js-basics-3/README.md
+++ b/modules/js-basics-3/README.md
@@ -18,7 +18,7 @@ At the end of this module you should pass the **"JS-basic. Part 3 (EN)"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 
 ### Task [Codewars: Strings, Numbers](../../tasks/codewars/codewars.strings.numbers.md)

--- a/modules/js-objects/README.md
+++ b/modules/js-objects/README.md
@@ -18,7 +18,7 @@ At the end of this module you should pass the **"JS Object. Basic"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 
 ### Task [Codewars: Array, Object](../../tasks/codewars/codewars.arrays.objects.md) 

--- a/modules/js-objects/README.md
+++ b/modules/js-objects/README.md
@@ -18,7 +18,7 @@ At the end of this module you should pass the **"JS Object. Basic"**
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 
 ### Task [Codewars: Array, Object](../../tasks/codewars/codewars.arrays.objects.md) 

--- a/modules/rs-school-intro/README.md
+++ b/modules/rs-school-intro/README.md
@@ -15,6 +15,6 @@ At the end of this module, you should pass the **"RS app intro"** test.
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be twice lower.
+* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 

--- a/modules/rs-school-intro/README.md
+++ b/modules/rs-school-intro/README.md
@@ -15,6 +15,6 @@ At the end of this module, you should pass the **"RS app intro"** test.
 * Tests submitted in RS School App could be solved after authorization in the application.
 * The minimum passing score is **90%** of the maximum possible number of points.
 * You can take the test **3 times**, the last result is counted.
-* You can try the test even more times, but the score for the test will be "reduced by half (from the original score)".
+* You can try the test even more times, but the score for the test will be reduced by half (from the original score).
 * The result of passing the test will be displayed immediately, it will be added to the score page next day after passing.
 


### PR DESCRIPTION
replace "twice lower" with "reduced by half (from the original score)" in the README.md files

@Anik188 Ma'am, i have rephrased the word "twice lower" with "reduced by half" in all the README files... In my humble opinion, it could improve the "readability" a tad bit.

PS: I closed my previous pull-request... I have read the "https://docs.rs.school/#/en/how-to-contribute" link & then sending this new pull-request.

It's totally fine if you decline this pull-request (in that case, please kindly let me know the proper procedure, so that i can send this the right way in future)...