### PR TITLE
docs: show "task-point breakdowns" via markdown table

### DIFF
--- a/tasks/codewars/codewars.arrays.objects.md
+++ b/tasks/codewars/codewars.arrays.objects.md
@@ -27,7 +27,7 @@
 10. 8 kyu https://www.codewars.com/kata/regular-ball-super-ball
 
 ## Scoring criteria
-| | Number of tasks | Points for each | Sub total Points |
+| Category | Number of tasks | Points for each | Sub total Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 3 | 3 | (3 * 3) = 9 |
 | 7 kyu | 12 | 3 | (12 * 3) = 36 |

--- a/tasks/codewars/codewars.arrays.objects.md
+++ b/tasks/codewars/codewars.arrays.objects.md
@@ -27,7 +27,7 @@
 10. 8 kyu https://www.codewars.com/kata/regular-ball-super-ball
 
 ## Scoring criteria
-| Category | Number of tasks | Points for each | Sub total Points |
+| Category | Number of tasks | Points for each task | Sub total Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 3 | 3 | (3 * 3) = 9 |
 | 7 kyu | 12 | 3 | (12 * 3) = 36 |

--- a/tasks/codewars/codewars.arrays.objects.md
+++ b/tasks/codewars/codewars.arrays.objects.md
@@ -27,7 +27,7 @@
 10. 8 kyu https://www.codewars.com/kata/regular-ball-super-ball
 
 ## Scoring criteria
-| Category | Number of tasks | Points for each task | Sub total Points |
+| Category | Number of tasks | Points for each task | Subtotal Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 3 | 3 | (3 * 3) = 9 |
 | 7 kyu | 12 | 3 | (12 * 3) = 36 |

--- a/tasks/codewars/codewars.arrays.objects.md
+++ b/tasks/codewars/codewars.arrays.objects.md
@@ -27,11 +27,13 @@
 10. 8 kyu https://www.codewars.com/kata/regular-ball-super-ball
 
 ## Scoring criteria
-3 point for 8 kyu tasks (3 tasks at all)  
-3 point for 7 kyu tasks (12 at all)  
-5 points for 6 kyu tasks (5 at all)  
-Total: 3 * 3 + 3 * 12 + 5 * 5 = 70
+| | Number of tasks | Points for each | Sub total Points |
+| --- | :---: | :---: | ---: |
+| 8 kyu | 3 | 3 | (3 * 3) = 9 |
+| 7 kyu | 12 | 3 | (12 * 3) = 36 |
+| 6 kyu | 5 | 5 | (5 * 5) = 25 |
+| | | **Total Points** = | (9 + 36 + 25) = **70** |
 
-**Total sum - 70 points**
+**Total sum = 70 points**
 
 

--- a/tasks/codewars/codewars.strings.numbers.md
+++ b/tasks/codewars/codewars.strings.numbers.md
@@ -24,7 +24,7 @@
 
 
 ## Scoring criteria
-| Category | Number of tasks | Points for each | Sub total Points |
+| Category | Number of tasks | Points for each task | Sub total Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 7 | 3 | (7 * 3) = 21 |
 | 7 kyu | 8 | 3 | (8 * 3) = 24 |

--- a/tasks/codewars/codewars.strings.numbers.md
+++ b/tasks/codewars/codewars.strings.numbers.md
@@ -24,11 +24,13 @@
 
 
 ## Scoring criteria
-3 point for 8 kyu tasks (7 tasks at all)  
-3 point for 7 kyu tasks (8 at all)  
-5 points for 6 kyu tasks (1 at all)  
-Total: 3 * 7 + 3 * 8 + 5 * 1 = 50
+| | Number of tasks | Points for each | Sub total Points |
+| --- | :---: | :---: | ---: |
+| 8 kyu | 7 | 3 | (7 * 3) = 21 |
+| 7 kyu | 8 | 3 | (8 * 3) = 24 |
+| 6 kyu | 5 | 1 | (5 * 1) = 5 |
+| | | **Total Points** = | (21 + 24 + 5) = **50** |
 
-**Total sum - 50 points**
+**Total sum = 50 points**
 
 

--- a/tasks/codewars/codewars.strings.numbers.md
+++ b/tasks/codewars/codewars.strings.numbers.md
@@ -24,7 +24,7 @@
 
 
 ## Scoring criteria
-| Category | Number of tasks | Points for each task | Sub total Points |
+| Category | Number of tasks | Points for each task | Subtotal Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 7 | 3 | (7 * 3) = 21 |
 | 7 kyu | 8 | 3 | (8 * 3) = 24 |

--- a/tasks/codewars/codewars.strings.numbers.md
+++ b/tasks/codewars/codewars.strings.numbers.md
@@ -24,7 +24,7 @@
 
 
 ## Scoring criteria
-| | Number of tasks | Points for each | Sub total Points |
+| Category | Number of tasks | Points for each | Sub total Points |
 | --- | :---: | :---: | ---: |
 | 8 kyu | 7 | 3 | (7 * 3) = 21 |
 | 7 kyu | 8 | 3 | (8 * 3) = 24 |


### PR DESCRIPTION
@pavelrazuvalau @Anik188 Hi, I'm proposing the following cosmetic changes to enhance the ease of readability.... The current view is:

![current](https://user-images.githubusercontent.com/100993044/160286823-59ef076f-8d5d-40a7-a104-80d721b83ef3.png)

---------------------------------------------------

I'm proposing the following view:

![modified](https://user-images.githubusercontent.com/100993044/160286841-61b1599f-bd74-4332-b3d5-3dbb4890609f.png)

-------------------------------------------------------

After 2nd commit the proposed view (I forgot to name one column-heading):

![final](https://user-images.githubusercontent.com/100993044/160288410-238257a9-f103-488f-ac7c-78d765ffa2d2.png)

-------------------------------------------------------------

After 3rd commit the proposed-view (I renamed the column "Points for each" with "Points for each task" for more clarity):


![final-iteration](https://user-images.githubusercontent.com/100993044/160292918-8c8b7b85-490d-42a9-aad8-3ee20ee5d28d.png)

-----------------------------------------------------------------

And, this is the 4th commit ( i needed to correct the spelling mistake in the "Sub total Points" column-name with the "Subtotal Points"):

![final-iteration](https://user-images.githubusercontent.com/100993044/160320122-976407d2-4c42-44cf-a703-31d83048288b.png)


Please, kindly let me know if my markdown code is not compliant OR the proposed view is not acceptable....
