### PR TITLE
fix: fix typo in "Task" & "Repo Requirements" section inside CV(HTML+CSS+Markdown).md

### DIFF
--- a/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
+++ b/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
@@ -1,7 +1,7 @@
 # "CV. HTML, CSS & Git Basics"
 
 ## Task
-Your task is to create your own CV using HTML and Css.
+Your task is to create your own CV using HTML and CSS.
 
 ### Repository Requirements:
 1. Continue working in the repository `rsschool-cv` created during the previous task [CV.Markdown](./CV(markdown).md)

--- a/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
+++ b/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
@@ -15,7 +15,7 @@ Your task is to create your own CV using HTML and Css.
    * The CV should work in the Google Chrome browser
    * There are in the footer: link to your name, github name, date, course logo with the link
    * In case you are worried about your private information - you may use fake data
-6. Inside the `README.md` in the `rsschool-cv-html` branch put the link `https://GITHUB-USERNAME.github.io/rsschool-cv/` wherhe the `GITHUB-USERNAME` is your github name. This link should lead to your CV created with HTML and Css
+6. Inside the `README.md` in the `rsschool-cv-html` branch put the link `https://GITHUB-USERNAME.github.io/rsschool-cv/` where the `GITHUB-USERNAME` is your github name. This link should lead to your CV created with HTML and Css
 7. Create the Pull Request from the `rsschool-cv-html` to `gh-pages`. The name of PR should be `HTML, CSS & Git Basics`
 8. Merge the Pull Request from the `rsschool-cv-html` to `gh-pages`
 

--- a/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
+++ b/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md
@@ -15,7 +15,7 @@ Your task is to create your own CV using HTML and Css.
    * The CV should work in the Google Chrome browser
    * There are in the footer: link to your name, github name, date, course logo with the link
    * In case you are worried about your private information - you may use fake data
-6. Inside the `README.md` in the `rsschool-cv-html` branch put the link `https://GITHUB-USERNAME.github.io/rsschool-cv/` where the `GITHUB-USERNAME` is your github name. This link should lead to your CV created with HTML and Css
+6. Inside the `README.md` in the `rsschool-cv-html` branch put the link `https://GITHUB-USERNAME.github.io/rsschool-cv/` where the `GITHUB-USERNAME` is your github name. This link should lead to your CV created with HTML and CSS
 7. Create the Pull Request from the `rsschool-cv-html` to `gh-pages`. The name of PR should be `HTML, CSS & Git Basics`
 8. Merge the Pull Request from the `rsschool-cv-html` to `gh-pages`
 


### PR DESCRIPTION
@pavelrazuvalau @andrei-shelenhouski @Anik188 

file: js-fe-course-en/tasks/CV(markdown)/CV(HTML+CSS+Markdown).md

There were three teeny-weeny typos in the "Task" & "Repository Requirements" section - fixed it...

(it's supposed to be - "where" instead of "wherhe" & "CSS" instead of "Css").