### PR TITLE
docs: Fix recommendation for separating selectors and properties

### DIFF
--- a/modules/clean-code/materials/html-and-css.md
+++ b/modules/clean-code/materials/html-and-css.md
@@ -377,12 +377,21 @@ Start each selector or rule on a new line.
 
 ```css
 /* Not recommended */
+a:focus, a:active {
+  position: relative; top: 1px;
+}
+
+h1, h2, h3 {
+  font-weight: normal;
+  line-height: 3.2;
+}
+
+/* Recommended */
 a:focus,
 a:active {
   position: relative; top: 1px;
 }
 
-/* Recommended */
 h1,
 h2,
 h3 {


### PR DESCRIPTION
# Clean Code S1E1

## HTML & CSS. Beginner level

[Section: 3.8. Separate selectors and properties](https://github.com/rolling-scopes-school/js-fe-course-en/blob/main/modules/clean-code/materials/html-and-css.md#38-separate-selectors-and-properties)

Written description:
> Separate selectors and properties with a line break.
> Start each selector or rule on a new line.

Before:
```css
/* Not recommended */
a:focus,
a:active {
  position: relative; top: 1px;
}
```

Kind a weird description for existing example...<br>
Suggestion:
```css
/* Not recommended */
a:focus, a:active {
  position: relative; top: 1px;
}

h1, h2, h3 {
  font-weight: normal;
  line-height: 3.2;
}

/* Recommended */
a:focus,
a:active {
  position: relative; top: 1px;
}

h1,
h2,
h3 {
  font-weight: normal;
  line-height: 3.2;
}
```