### PR TITLE
fix: correct 'carrying' into 'currying'

### DIFF
--- a/modules/interview-core-js/interview.md
+++ b/modules/interview-core-js/interview.md
@@ -72,7 +72,7 @@
     - Understand callback limitations (callback hell) `(optional)`
     - Binding, binding one function twice
     - Know how to bind `this` scope to function
-    - Carrying and partial functions
+    - Currying and partial functions
 
 - #### Network requests
 


### PR DESCRIPTION
There was used term `Carrying and partial functions`. The "carrying"-s  use - in context with "partials functions" - clearly shows there was typo because `currying` and `partial functions` are very close concepts.